### PR TITLE
Feat/node/prompt

### DIFF
--- a/llmflow-studio/src/App.vue
+++ b/llmflow-studio/src/App.vue
@@ -60,16 +60,18 @@
   }
 
   function onNodeClick() {
-    // 노드 클릭 시 강제 리렌더링
-    nodes.value = [...nodes.value]
+    // 노드 클릭 시 강제 리렌더링 제거
+    console.log('Node clicked:', nodes.value)
   }
 
   function onNodesChange(changes) {
-    // 노드 변경 시 강제 리렌더링
+    // 노드 변경 시 업데이트 최적화
     console.log('Nodes changed:', changes)
-    // 다음 틱에서 강제 업데이트
-    nextTick(() => {
-      nodes.value = [...nodes.value]
+    changes.forEach(change => {
+      const index = nodes.value.findIndex(node => node.id === change.id)
+      if (index !== -1) {
+        Object.assign(nodes.value[index], change)
+      }
     })
   }
 

--- a/llmflow-studio/src/App.vue
+++ b/llmflow-studio/src/App.vue
@@ -60,18 +60,16 @@
   }
 
   function onNodeClick() {
-    // 노드 클릭 시 강제 리렌더링 제거
-    console.log('Node clicked:', nodes.value)
+    // 노드 클릭 시 강제 리렌더링
+    nodes.value = [...nodes.value]
   }
 
   function onNodesChange(changes) {
-    // 노드 변경 시 업데이트 최적화
+    // 노드 변경 시 강제 리렌더링
     console.log('Nodes changed:', changes)
-    changes.forEach(change => {
-      const index = nodes.value.findIndex(node => node.id === change.id)
-      if (index !== -1) {
-        Object.assign(nodes.value[index], change)
-      }
+    // 다음 틱에서 강제 업데이트
+    nextTick(() => {
+      nodes.value = [...nodes.value]
     })
   }
 

--- a/llmflow-studio/src/App.vue
+++ b/llmflow-studio/src/App.vue
@@ -30,6 +30,7 @@
   import '@/assets/scss/App.css'
   import '@/assets/scss/ControlsFix.css'
 
+  const { applyNodeChanges } = useVueFlow()
   const dark = ref(false)
   const { nodes, edges, setNodes, setEdges, addEdges } = useVueFlow()
 
@@ -66,11 +67,7 @@
 
   function onNodesChange(changes) {
     // 노드 변경 시 강제 리렌더링
-    console.log('Nodes changed:', changes)
-    // 다음 틱에서 강제 업데이트
-    nextTick(() => {
-      nodes.value = [...nodes.value]
-    })
+    nodes.value = applyNodeChanges(changes)
   }
 
   // 다크 모드 상태에 따라 body class 토글

--- a/llmflow-studio/src/App.vue
+++ b/llmflow-studio/src/App.vue
@@ -5,6 +5,8 @@
       :edges="edges"
       :nodeTypes="nodeTypes"
       @connect="onConnect"
+      @nodeClick="onNodeClick"
+      @nodesChange="onNodesChange"
     >
       <AppBackground :dark="dark" />
       <Controls position="top-left">
@@ -17,7 +19,7 @@
 </template>
 
 <script setup>
-  import { onMounted, ref, watch } from 'vue'
+  import { onMounted, ref, watch, nextTick } from 'vue'
   import { VueFlow, useVueFlow } from '@vue-flow/core'
   import { Controls, ControlButton } from '@vue-flow/controls'
   import '@vue-flow/core/dist/style.css'
@@ -57,6 +59,20 @@
     ])
   }
 
+  function onNodeClick() {
+    // 노드 클릭 시 강제 리렌더링
+    nodes.value = [...nodes.value]
+  }
+
+  function onNodesChange(changes) {
+    // 노드 변경 시 강제 리렌더링
+    console.log('Nodes changed:', changes)
+    // 다음 틱에서 강제 업데이트
+    nextTick(() => {
+      nodes.value = [...nodes.value]
+    })
+  }
+
   // 다크 모드 상태에 따라 body class 토글
   watch(dark, (val) => {
     if (val) {
@@ -76,10 +92,25 @@
         ...updatedNodes[index],
         data: {
           ...updatedNodes[index].data,
-          modelValue: newData
+          modelValue: newData,
+          // 이벤트 핸들러를 다시 설정
+          onUpdateModelValue: (newValue) => {
+            updateNodeData(nodeId, newValue)
+            nodes.value = [...nodes.value]
+          },
+          onNodeDataChanged: (event) => {
+            handleNodeDataChanged(event)
+            nodes.value = [...nodes.value]
+          }
         }
       }
       setNodes(updatedNodes)
+      console.log(`Node ${nodeId} updated with data:`, newData)
+
+      // 강제 리렌더링
+      nextTick(() => {
+        nodes.value = [...nodes.value]
+      })
     } else {
       console.warn(
         `ID가 ${nodeId}인 노드를 찾을 수 없어 업데이트할 수 없습니다.`
@@ -94,9 +125,23 @@
 
   const nodesWithEvents = initialNodes.map((node) => ({
     ...node,
-    events: {
-      'update:modelValue': (newValue) => updateNodeData(node.id, newValue),
-      'node-data-changed': handleNodeDataChanged
+    // VueFlow에서 노드 컴포넌트에 props를 전달하는 방식
+    data: {
+      ...node.data,
+      // modelValue를 직접 props로 전달
+      modelValue: node.data.modelValue,
+      id: node.id,
+      // 이벤트 핸들러를 data에 포함시켜 props로 전달
+      onUpdateModelValue: (newValue) => {
+        updateNodeData(node.id, newValue)
+        // 강제로 반응성 트리거를 위해 nodes 배열을 새로 생성
+        nodes.value = [...nodes.value]
+      },
+      onNodeDataChanged: (event) => {
+        handleNodeDataChanged(event)
+        // 강제로 반응성 트리거를 위해 nodes 배열을 새로 생성
+        nodes.value = [...nodes.value]
+      }
     }
   }))
 

--- a/llmflow-studio/src/components/nodes/PromptNode/PromptNode.vue
+++ b/llmflow-studio/src/components/nodes/PromptNode/PromptNode.vue
@@ -96,35 +96,59 @@
   import { Handle } from '@vue-flow/core'
 
   const props = defineProps({
-    modelValue: {
+    // VueFlow에서 전달되는 data 객체
+    data: {
       type: Object,
-      default: () => ({ role: 'system', context: '' })
+      default: () => ({})
     },
+    // VueFlow 노드의 기본 props들
     id: {
       type: String,
       default: ''
+    },
+    // 직접 전달되는 modelValue (fallback용)
+    modelValue: {
+      type: Object,
+      default: () => ({ role: 'system', context: '' })
     }
   })
+
+  // data.modelValue가 있으면 우선 사용하고, 없으면 props.modelValue 사용
+  const getModelValue = () => {
+    return (
+      props.data?.modelValue ||
+      props.modelValue || { role: 'system', context: '' }
+    )
+  }
+
+  // 이벤트 핸들러를 data에서 가져오기
+  const getEventHandlers = () => {
+    return {
+      onUpdateModelValue: props.data?.onUpdateModelValue,
+      onNodeDataChanged: props.data?.onNodeDataChanged
+    }
+  }
 
   const emit = defineEmits(['update:modelValue', 'node-data-changed'])
 
   const isExpanded = ref(false)
   const isDropdownOpen = ref(false)
-  const inputText = ref(props.modelValue.context)
-  const currentRole = ref(props.modelValue.role)
+  const inputText = ref(getModelValue().context)
+  const currentRole = ref(getModelValue().role)
   const options = ref(['system', 'assistant', 'user'])
   const dropdownMenu = ref(null)
   const dropdownHeight = ref(0)
 
   // 초기값 설정
   onMounted(() => {
-    currentRole.value = props.modelValue.role
-    inputText.value = props.modelValue.context
+    const modelValue = getModelValue()
+    currentRole.value = modelValue.role
+    inputText.value = modelValue.context
   })
 
   // 모델 값이 외부에서 변경되었을 때 로컬 상태 업데이트
   watch(
-    () => props.modelValue,
+    () => getModelValue(),
     (newValue) => {
       currentRole.value = newValue.role
       inputText.value = newValue.context
@@ -162,10 +186,30 @@
 
     // 부모 컴포넌트에 알림
     const updatedValue = { role: option, context: inputText.value }
-    emit('update:modelValue', updatedValue)
+    console.log('PromptNode selectOption:', updatedValue)
 
-    if (props.id) {
-      emit('node-data-changed', { id: props.id, data: updatedValue })
+    // 이벤트 핸들러 가져오기
+    const eventHandlers = getEventHandlers()
+    console.log('Event handlers:', eventHandlers)
+
+    // data에 정의된 이벤트 핸들러가 있으면 사용
+    if (eventHandlers.onUpdateModelValue) {
+      console.log('Calling onUpdateModelValue')
+      eventHandlers.onUpdateModelValue(updatedValue)
+    }
+
+    // VueFlow 노드 ID 사용 (data.id 우선, 없으면 props.id)
+    const nodeId = props.data?.id || props.id
+    console.log('Node ID:', nodeId)
+    if (nodeId && eventHandlers.onNodeDataChanged) {
+      console.log('Calling onNodeDataChanged')
+      eventHandlers.onNodeDataChanged({ id: nodeId, data: updatedValue })
+    }
+
+    // fallback으로 emit도 실행
+    emit('update:modelValue', updatedValue)
+    if (nodeId) {
+      emit('node-data-changed', { id: nodeId, data: updatedValue })
     }
 
     isDropdownOpen.value = false
@@ -175,10 +219,25 @@
   // 텍스트 변경 감지
   watch(inputText, (newValue) => {
     const updatedValue = { role: currentRole.value, context: newValue }
-    emit('update:modelValue', updatedValue)
 
-    if (props.id) {
-      emit('node-data-changed', { id: props.id, data: updatedValue })
+    // 이벤트 핸들러 가져오기
+    const eventHandlers = getEventHandlers()
+
+    // data에 정의된 이벤트 핸들러가 있으면 사용
+    if (eventHandlers.onUpdateModelValue) {
+      eventHandlers.onUpdateModelValue(updatedValue)
+    }
+
+    // VueFlow 노드 ID 사용 (data.id 우선, 없으면 props.id)
+    const nodeId = props.data?.id || props.id
+    if (nodeId && eventHandlers.onNodeDataChanged) {
+      eventHandlers.onNodeDataChanged({ id: nodeId, data: updatedValue })
+    }
+
+    // fallback으로 emit도 실행
+    emit('update:modelValue', updatedValue)
+    if (nodeId) {
+      emit('node-data-changed', { id: nodeId, data: updatedValue })
     }
   })
 

--- a/llmflow-studio/src/components/nodes/PromptNode/PromptNode.vue
+++ b/llmflow-studio/src/components/nodes/PromptNode/PromptNode.vue
@@ -148,12 +148,13 @@
 
   // 모델 값이 외부에서 변경되었을 때 로컬 상태 업데이트
   watch(
-    () => getModelValue(),
-    (newValue) => {
+    [() => props.data?.modelValue, () => props.modelValue],
+    () => {
+      const newValue = getModelValue()
       currentRole.value = newValue.role
       inputText.value = newValue.context
     },
-    { deep: true }
+    { immediate: true }
   )
 
   const toggleExpansion = () => {

--- a/llmflow-studio/src/components/nodes/PromptNode/PromptNode.vue
+++ b/llmflow-studio/src/components/nodes/PromptNode/PromptNode.vue
@@ -186,23 +186,18 @@
 
     // 부모 컴포넌트에 알림
     const updatedValue = { role: option, context: inputText.value }
-    console.log('PromptNode selectOption:', updatedValue)
 
     // 이벤트 핸들러 가져오기
     const eventHandlers = getEventHandlers()
-    console.log('Event handlers:', eventHandlers)
 
     // data에 정의된 이벤트 핸들러가 있으면 사용
     if (eventHandlers.onUpdateModelValue) {
-      console.log('Calling onUpdateModelValue')
       eventHandlers.onUpdateModelValue(updatedValue)
     }
 
     // VueFlow 노드 ID 사용 (data.id 우선, 없으면 props.id)
     const nodeId = props.data?.id || props.id
-    console.log('Node ID:', nodeId)
     if (nodeId && eventHandlers.onNodeDataChanged) {
-      console.log('Calling onNodeDataChanged')
       eventHandlers.onNodeDataChanged({ id: nodeId, data: updatedValue })
     }
 


### PR DESCRIPTION
This pull request introduces changes to improve the reactivity and event handling of VueFlow nodes in the `llmflow-studio` application. The updates ensure that node data changes trigger proper re-renders and streamline how event handlers are managed and invoked. Key changes include adding new event handlers, modifying data structures to include handlers, and enhancing the `PromptNode` component's logic.

### Enhancements to Node Event Handling and Reactivity:

* **Added event handlers for node interactions in `App.vue`:** Introduced `onNodeClick` and `onNodesChange` handlers to trigger forced re-renders when nodes are clicked or modified. These handlers utilize `nextTick` to ensure the updates are applied reactively. 
* **Modified node data structure to include event handlers:** Updated the `nodesWithEvents` mapping logic to embed `onUpdateModelValue` and `onNodeDataChanged` handlers directly into the `data` object of each node. This ensures that event handlers are passed as props to node components.

### Updates to `PromptNode` Component:

* **Refactored to use `data` for event handling and props:** The `PromptNode` component now prioritizes `data` properties (e.g., `modelValue`, event handlers) over directly passed props, improving consistency and flexibility.
* **Centralized event handler invocation:** Added helper functions to retrieve event handlers from `data` and invoke them when node data changes, ensuring all updates propagate correctly. Fallbacks to `emit` are also maintained for compatibility.

### Miscellaneous:

* **Imported `nextTick` in `App.vue`:** Added `nextTick` to the imports to facilitate reactive updates after node changes.